### PR TITLE
Tweaks for Internal Timing Modes

### DIFF
--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -792,6 +792,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageMultiple:
+		pDetector_->SetNumOfExposures(numImages);
 		pDetector_->ToggleGenerator(false);
 		pDetector_->DisablePulseGenerator();
         pDetector_->GoLiveSeq();
@@ -799,6 +800,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageContinuous:
+		pDetector_->SetNumOfExposures(1.);
 		pDetector_->EnablePulseGenerator(1 / (acquirePeriod));
 		pDetector_->ToggleGenerator(true);
         pDetector_->GoLiveSeq();


### PR DESCRIPTION
Use imageMode to enable/disable internal pulse generator (only use when streaming/Continuous). 
