### PR TITLE
Tweaks for Internal Timing modes

### DIFF
--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -800,8 +800,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageContinuous:
-		pDetector_->SetNumOfExposures(1.);
-		pDetector_->EnablePulseGenerator(1 / (acquirePeriod));
+		pDetector_->EnablePulseGenerator(1 / (acquireTime + gap));
 		pDetector_->ToggleGenerator(true);
         pDetector_->GoLiveSeq();
         break;

--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -792,6 +792,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageMultiple:
+		pDetector_->SetNumOfExposures(numImages);
 		pDetector_->ToggleGenerator(false);
 		pDetector_->DisablePulseGenerator();
         pDetector_->GoLiveSeq();
@@ -799,6 +800,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageContinuous:
+		pDetector_->SetNumOfExposures(1.);
 		pDetector_->EnablePulseGenerator(1 / (acquirePeriod));
 		pDetector_->ToggleGenerator(true);
         pDetector_->GoLiveSeq();

--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -800,6 +800,7 @@ void Dexela::acquireStart(void)
         break;
 
       case ADImageContinuous:
+		pDetector_->SetNumOfExposures(1);
 		pDetector_->EnablePulseGenerator(1 / (acquireTime + gap));
 		pDetector_->ToggleGenerator(true);
         pDetector_->GoLiveSeq();


### PR DESCRIPTION
Use imageMode to determine enable/disable status of internal pulse generator (only use for Continuous image streaming).
