### PR TITLE
base frame time stamp on epicsTS

### DIFF
--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -349,7 +349,6 @@ void Dexela::newFrameCallback(int frameCounter, int bufferNumber)
   size_t        dims[2];
   NDArray       *pImage;
   NDDataType_t  dataType = NDUInt16;
-  epicsTimeStamp currentTime;
   DexImage      dataImage;
   static const char *functionName = "newFrameCallback";
     
@@ -507,9 +506,8 @@ void Dexela::newFrameCallback(int frameCounter, int bufferNumber)
 
       /* Put the frame number and time stamp into the buffer */
       pImage->uniqueId = frameCounter;
-      epicsTimeGetCurrent(&currentTime);
-      pImage->timeStamp = currentTime.secPastEpoch + currentTime.nsec / 1.e9;
       updateTimeStamp(&pImage->epicsTS);
+      pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
       /* Get any attributes that have been defined for this driver */
       getAttributes(pImage->pAttributeList);

--- a/dexelaApp/src/Dexela.cpp
+++ b/dexelaApp/src/Dexela.cpp
@@ -506,8 +506,7 @@ void Dexela::newFrameCallback(int frameCounter, int bufferNumber)
 
       /* Put the frame number and time stamp into the buffer */
       pImage->uniqueId = frameCounter;
-      updateTimeStamp(&pImage->epicsTS);
-      pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
+      updateTimeStamps(pImage);
 
       /* Get any attributes that have been defined for this driver */
       getAttributes(pImage->pAttributeList);


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.